### PR TITLE
Correctly handle numbers in morse conversion

### DIFF
--- a/inc/default.class.php
+++ b/inc/default.class.php
@@ -169,7 +169,7 @@ class Convrtr {
 	 * returns array
 	 */
 	function morseMap() {
-		$map = array (
+		$map = array(
 			'0' => '----- ','1' => '.---- ','2' => '..--- ','3' => '...-- ','4' => '....- ','5' => '..... ','6' => '-.... ','7' => '--... ',
 			'8' => '---.. ','\'' => '.----. ','9' => '----. ','B' => '-... ',',' => '-.-.-. ','@' => '.--.-. ','C' => '-.-. ','"' => '.-..-. ','/' => '-..-. ',
 			'F' => '..-. ','(' => '-.--. ','P' => '.--. ','G' => '--. ','H' => '.... ','J' => '.--- ',')' => '-.--.- ','Q' => '--.- ',
@@ -188,12 +188,12 @@ class Convrtr {
 	 */
 	function strToMorse($string) {
 		$maps = $this->morseMap();
-
 		$string = str_split(strtoupper($string));
 		$converted = array();
+
 		foreach ($string as $letter) {
 			foreach ($maps as $input => $output) {
-				if ($letter === $input) {
+				if ($letter === (string)$input) {
 					$converted[] = $output;
 				}
 			}


### PR DESCRIPTION
When converting strings to morse, we need to cast map index we want t…o check against to a string

If we don't then PHP will treat all the morse numbered keys as integers and return nothing for those values